### PR TITLE
Keep original order of categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Takes an opinionated view on what should be included so not everything is. The g
   "title":       "<Podcast title>",
   "description": {
     "short":       "<Podcast subtitle>",
-    "description": "<Podcast description>"
+    "long":        "<Podcast description>"
   },
   "link":       "<Podcast link (usually website for podcast)>",
   "image":      "<Podcast image>",

--- a/src/index.js
+++ b/src/index.js
@@ -67,7 +67,13 @@ module.exports = function parse(feedXML, callback) {
         tmp = tmp.parent;
       }
 
-      result.categories.push(path.join('>'));
+      const lastCategoryIndex = result.categories.length - 1;
+      if (result.categories[lastCategoryIndex] === path[0]) {
+        // overwrite last category because this one is more specific
+        result.categories[lastCategoryIndex] = path.join('>');
+      } else {
+        result.categories.push(path.join('>'));
+      }
     } else if (node.name === 'item' && node.parent.name === 'channel') {
       // New item
       tmpEpisode = {

--- a/src/index.js
+++ b/src/index.js
@@ -175,7 +175,7 @@ module.exports = function parse(feedXML, callback) {
       }
     }
 
-    result.categories = _.uniq(result.categories.sort());
+    result.categories = _.uniq(result.categories);
 
     callback(null, result);
   }

--- a/test/tests.js
+++ b/test/tests.js
@@ -111,9 +111,9 @@ describe('Podcast feed parser', () => {
           email: 'john.doe@example.com'
         },
         categories: [
-          'TV & Film',
           'Technology',
-          'Technology>Gadgets'
+          'Technology>Gadgets',
+          'TV & Film',
         ]
       });
 
@@ -247,10 +247,10 @@ describe('Podcast feed parser', () => {
       if (err) {
         return done(err);
       }
-      
+
       const podcast = Object.assign({}, data);
       delete podcast.episodes;
-      
+
        expect(podcast).to.eql({
          title: 'Tiempo de valientes. El diario de Julián Martínez',
         description: {
@@ -261,12 +261,12 @@ describe('Podcast feed parser', () => {
         language: 'es-es',
         updated: utcDate(2016, 4, 17, 12, 08, 49),
         owner: {
-         
+
         },
         categories: [
         ]
       });
-      
+
       done();
     });
   });
@@ -351,9 +351,9 @@ describe('Podcast feed parser', () => {
           email: 'designdetailsfm@gmail.com'
         },
         categories: [
+          'Technology',
           'Arts',
           'Arts>Design',
-          'Technology',
           'Technology>Podcasting'
         ]
       });


### PR DESCRIPTION
I think the order of categories in the feed is intentional, and it looks like iTunes for example only lists you in the first/primary one.

So a small change - removing the sort() in categories output.