### PR TITLE
Add explicit property. Parse episode descriptions with <description> tag in addition to <itunes:summary>

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Takes an opinionated view on what should be included so not everything is. The g
   "language":   "<ISO 639 language>",
   "copyright":  "<Podcast copyright>",
   "updated":    "<pubDate or latest episode pubDate>",
+  "explicit":   "<Podcast is explicit, true/false>",
   "categories": [
     "Category>Subcategory"
   ],
@@ -33,6 +34,7 @@ Takes an opinionated view on what should be included so not everything is. The g
       "guid":        "<Unique id>",
       "title":       "<Episode title>",
       "description": "<Episode description>",
+      "explicit":    "<Episodeis is explicit, true/false>",
       "image":       "<Episode image>",
       "published":   "<date>",
       "duration":    120,

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Takes an opinionated view on what should be included so not everything is. The g
       "guid":        "<Unique id>",
       "title":       "<Episode title>",
       "description": "<Episode description>",
-      "explicit":    "<Episodeis is explicit, true/false>",
+      "explicit":    "<Episode is is explicit, true/false>",
       "image":       "<Episode image>",
       "published":   "<date>",
       "duration":    120,

--- a/src/index.js
+++ b/src/index.js
@@ -49,6 +49,7 @@ module.exports = function parse(feedXML, callback) {
         'description': 'description.long',
         'ttl': text => { return { ttl: parseInt(text) }; },
         'pubDate': text => { return { updated: new Date(text) }; },
+        'itunes:explicit': isExplicit,
       };
     } else if (node.name === 'itunes:image' && node.parent.name === 'channel') {
       result.image = node.attributes.href;
@@ -100,7 +101,8 @@ module.exports = function parse(feedXML, callback) {
                 return acc + parseInt(val) * muliplier;
               }, 0)
           };
-        }
+        },
+        'itunes:explicit': isExplicit,
       };
     } else if (tmpEpisode) {
       // Episode specific attributes
@@ -196,4 +198,10 @@ module.exports = function parse(feedXML, callback) {
   } catch (error) {
     callback(error);
   }
+}
+
+function isExplicit(text) {
+  return {
+    explicit: (text || '').toLowerCase() === 'yes',
+  };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,8 @@ module.exports = function parse(feedXML, callback) {
       node.textMap = {
         'title': true,
         'guid': true,
-        'itunes:summary': 'description',
+        'itunes:summary': 'description.primary',
+        'description': 'description.alternate',
         'pubDate': text => { return { published: new Date(text) }; },
         'itunes:duration': text => {
           return {
@@ -123,6 +124,8 @@ module.exports = function parse(feedXML, callback) {
       if (!result.episodes) {
         result.episodes = [];
       }
+      // coalesce descriptions (no breaking change)
+      tmpEpisode.description = tmpEpisode.description.primary || tmpEpisode.description.alternate;
       result.episodes.push(tmpEpisode);
       tmpEpisode = null;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -127,7 +127,11 @@ module.exports = function parse(feedXML, callback) {
         result.episodes = [];
       }
       // coalesce descriptions (no breaking change)
-      tmpEpisode.description = tmpEpisode.description.primary || tmpEpisode.description.alternate;
+      let description = '';
+      if (tmpEpisode.description) {
+        description = tmpEpisode.description.primary || tmpEpisode.description.alternate || '';
+      }
+      tmpEpisode.description = description;
       result.episodes.push(tmpEpisode);
       tmpEpisode = null;
     }

--- a/test/fixtures/apple-example.xml
+++ b/test/fixtures/apple-example.xml
@@ -14,6 +14,7 @@
       <itunes:email>john.doe@example.com</itunes:email>
     </itunes:owner>
     <itunes:image href="http://example.com/podcasts/everything/AllAboutEverything.jpg"/>
+    <itunes:explicit>yes</itunes:explicit>
     <itunes:category text="Technology">
       <itunes:category text="Gadgets"/>
     </itunes:category>
@@ -30,6 +31,7 @@
       <guid>http://example.com/podcasts/archive/aae20140615.m4a</guid>
       <pubDate>Wed, 15 Jun 2014 19:00:00 GMT</pubDate>
       <itunes:duration>7:04</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
     </item>
     <item>
       <title>Socket Wrench Shootout</title>
@@ -41,6 +43,7 @@
       <guid>http://example.com/podcasts/archive/aae20140608.mp3</guid>
       <pubDate>Wed, 8 Jun 2014 19:00:00 GMT</pubDate>
       <itunes:duration>4:34</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
     </item>
     <item>
       <title>Red,Whine, &amp; Blue</title>
@@ -52,6 +55,7 @@
       <guid>http://example.com/podcasts/archive/aae20140601.mp3</guid>
       <pubDate>Wed, 1 Jun 2014 19:00:00 GMT</pubDate>
       <itunes:duration>3:59</itunes:duration>
+      <itunes:explicit>yes</itunes:explicit>
     </item>
   </channel>
 </rss>

--- a/test/fixtures/libsyn-example-podcast.xml
+++ b/test/fixtures/libsyn-example-podcast.xml
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:cc="http://web.resource.org/cc/" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:media="http://search.yahoo.com/mrss/" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+	<channel>
+		<atom:link href="http://frankanderik.libsyn.com/rss" rel="self" type="application/rss+xml"/>
+		<title>Frank and Erik Internet Famous</title>
+		<pubDate>Fri, 21 Apr 2017 03:12:13 +0000</pubDate>
+		<lastBuildDate>Thu, 23 Nov 2017 16:16:45 +0000</lastBuildDate>
+		<generator>Libsyn WebEngine 2.0</generator>
+		<link>http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewPodcast?id=301089844</link>
+		<language>en</language>
+		<copyright><![CDATA[]]></copyright>
+		<docs>http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewPodcast?id=301089844</docs>
+		<managingEditor>frankanderik@gmail.com (frankanderik@gmail.com)</managingEditor>
+		<itunes:summary><![CDATA[A podcast about being a man-child in the big city.]]></itunes:summary>
+		<image>
+			<url>http://static.libsyn.com/p/assets/0/a/0/1/0a015c5ace601833/InternetFamousArt.jpg</url>
+			<title>Frank and Erik Internet Famous</title>
+			<link><![CDATA[http://itunes.apple.com/WebObjects/MZStore.woa/wa/viewPodcast?id=301089844]]></link>
+		</image>
+		<itunes:author>Frank and Erik</itunes:author>
+		<itunes:category text="Comedy"/>
+		<itunes:image href="http://static.libsyn.com/p/assets/0/a/0/1/0a015c5ace601833/InternetFamousArt.jpg" />
+		<itunes:explicit>yes</itunes:explicit>
+		<itunes:owner>
+			<itunes:name><![CDATA[Frank and Erik]]></itunes:name>
+			<itunes:email>frankanderik@gmail.com</itunes:email>
+		</itunes:owner>
+		<description><![CDATA[A podcast about being a man-child in the big city.]]></description>
+		<itunes:subtitle><![CDATA[A podcast about being a man-child in the big city.]]></itunes:subtitle>
+		<itunes:type>episodic</itunes:type>
+				<item>
+			<title>Episode 128</title>
+			<pubDate>Fri, 21 Apr 2017 03:12:13 +0000</pubDate>
+			<guid isPermaLink="false"><![CDATA[1bdba530eb7cd0fb6241a945fda4db95]]></guid>
+			<link><![CDATA[http://frankanderik.libsyn.com/episode-128]]></link>
+			<itunes:image href="http://static.libsyn.com/p/assets/0/a/0/1/0a015c5ace601833/InternetFamousArt.jpg" />
+			<description><![CDATA[<p>Frank and Erik travel the world.</p> <p>Outro: 20/20 - Yellow Pills</p> <p>646-434-8528</p> <p>frankanderik.com</p>]]></description>
+			<content:encoded><![CDATA[<p>Frank and Erik travel the world.</p> <p>Outro: 20/20 - Yellow Pills</p> <p>646-434-8528</p> <p>frankanderik.com</p>]]></content:encoded>
+			<enclosure length="45813708" type="audio/mpeg" url="http://traffic.libsyn.com/frankanderik/Internet_Famous_Ep128.mp3?dest-id=30697" />
+			<itunes:duration>01:35:02</itunes:duration>
+			<itunes:explicit>no</itunes:explicit>
+			<itunes:keywords />
+			<itunes:subtitle><![CDATA[Frank and Erik travel the world. Outro: 20/20 - Yellow Pills 646-434-8528 frankanderik.com]]></itunes:subtitle>
+					</item>
+		<item>
+			<title>Episode 127</title>
+			<pubDate>Tue, 18 Oct 2016 02:58:12 +0000</pubDate>
+			<guid isPermaLink="false"><![CDATA[af2d85626546b41822e4876b08c7c88d]]></guid>
+			<link><![CDATA[http://frankanderik.libsyn.com/episode-127]]></link>
+			<itunes:image href="http://static.libsyn.com/p/assets/0/a/0/1/0a015c5ace601833/InternetFamousArt.jpg" />
+			<description><![CDATA[<p>Frank and Erik have had a busy year.</p> <p>Outro: Buzzcocks - Why Can't I Touch It</p> <p>646-434-8528</p> <p>frankanderik.com</p>]]></description>
+			<content:encoded><![CDATA[<p>Frank and Erik have had a busy year.</p> <p>Outro: Buzzcocks - Why Can't I Touch It</p> <p>646-434-8528</p> <p>frankanderik.com</p>]]></content:encoded>
+			<enclosure length="65798653" type="audio/mpeg" url="http://traffic.libsyn.com/frankanderik/Internet_Famous_Ep127.mp3?dest-id=30697" />
+			<itunes:duration>02:16:40</itunes:duration>
+			<itunes:explicit>no</itunes:explicit>
+			<itunes:keywords />
+			<itunes:subtitle><![CDATA[Frank and Erik have had a busy year. Outro: Buzzcocks - Why Can't I Touch It 646-434-8528 frankanderik.com]]></itunes:subtitle>
+					</item>
+		<item>
+			<title>Episode 126</title>
+			<pubDate>Fri, 15 Apr 2016 01:41:36 +0000</pubDate>
+			<guid isPermaLink="false"><![CDATA[f73f4600f598ace9b906228f1a99900d]]></guid>
+			<link><![CDATA[http://frankanderik.libsyn.com/episode-126]]></link>
+			<itunes:image href="http://static.libsyn.com/p/assets/0/a/0/1/0a015c5ace601833/InternetFamousArt.jpg" />
+			<description><![CDATA[<p>Frank makes the right choice when faced with the opportunity to go to a sex club, Erik is probably dying and Frank's inbox is wide open.</p>
+<p>Outro: Dopethrone - Dry Hitter</p>
+<p>646-434-8528</p>
+<p>frankanderik.com</p>]]></description>
+			<content:encoded><![CDATA[<p>Frank makes the right choice when faced with the opportunity to go to a sex club, Erik is probably dying and Frank's inbox is wide open.</p>
+<p>Outro: Dopethrone - Dry Hitter</p>
+<p>646-434-8528</p>
+<p>frankanderik.com</p>]]></content:encoded>
+			<enclosure length="39539512" type="audio/mpeg" url="http://traffic.libsyn.com/frankanderik/Internet_Famous_Ep126.mp3?dest-id=30697" />
+			<itunes:duration>01:21:57</itunes:duration>
+			<itunes:explicit>no</itunes:explicit>
+			<itunes:keywords />
+			<itunes:subtitle><![CDATA[Frank makes the right choice when faced with the opportunity to go to a sex club, Erik is probably dying and Frank's inbox is wide open.
+Outro: Dopethrone - Dry Hitter
+646-434-8528
+frankanderik.com]]></itunes:subtitle>
+					</item>
+		<item>
+			<title>Episode 125</title>
+			<pubDate>Tue, 15 Mar 2016 03:34:45 +0000</pubDate>
+			<guid isPermaLink="false"><![CDATA[0ac333fe9a65f80b26110eaf8ee16435]]></guid>
+			<link><![CDATA[http://frankanderik.libsyn.com/episode-125]]></link>
+			<itunes:image href="http://static.libsyn.com/p/assets/0/a/0/1/0a015c5ace601833/InternetFamousArt.jpg" />
+			<description><![CDATA[<p>Erik relaxes a little, foot updates and Frank teases his upcoming adventures in New York's bizarro underground.</p>
+<p>Outro: LVL UP - The Closing Door</p>
+<p>646-434-8528</p>
+<p>frankanderik.com</p>]]></description>
+			<content:encoded><![CDATA[<p>Erik relaxes a little, foot updates and Frank teases his upcoming adventures in New York's bizarro underground.</p>
+<p>Outro: LVL UP - The Closing Door</p>
+<p>646-434-8528</p>
+<p>frankanderik.com</p>]]></content:encoded>
+			<enclosure length="43767579" type="audio/mpeg" url="http://traffic.libsyn.com/frankanderik/Internet_Famous_Ep125.mp3?dest-id=30697" />
+			<itunes:duration>01:30:46</itunes:duration>
+			<itunes:explicit>no</itunes:explicit>
+			<itunes:keywords />
+			<itunes:subtitle><![CDATA[Erik relaxes a little, foot updates and Frank teases his upcoming adventures in New York's bizarro underground.
+Outro: LVL UP - The Closing Door
+646-434-8528
+frankanderik.com]]></itunes:subtitle>
+					</item>
+		<item>
+			<title>Episode 124</title>
+			<pubDate>Mon, 30 Nov 2015 01:43:51 +0000</pubDate>
+			<guid isPermaLink="false"><![CDATA[153d3c523e8e4fff8435bdb9b7a963c5]]></guid>
+			<link><![CDATA[http://frankanderik.libsyn.com/episode-124]]></link>
+			<itunes:image href="http://static.libsyn.com/p/assets/0/a/0/1/0a015c5ace601833/InternetFamousArt.jpg" />
+			<description><![CDATA[<p>Erk gets a little bit self righteous and Frank attempts to talk him down from a ledge.</p>
+<p>Break: Living With Lions - Pieces</p>
+<p>Outro: H2O - 5 Yr. Plan</p>
+<p>646-434-8528</p>
+<p>frankanderik.com</p>
+<p>Erik's Movember Page: <a href="http://mobro.co/erikcore">http://mobro.co/erikcore</a></p>
+<p>Frank's Movember Page: <a href="http://mobro.co/frankaugugliaro">http://mobro.co/frankaugugliaro</a></p>
+<p> </p>]]></description>
+			<content:encoded><![CDATA[<p>Erk gets a little bit self righteous and Frank attempts to talk him down from a ledge.</p>
+<p>Break: Living With Lions - Pieces</p>
+<p>Outro: H2O - 5 Yr. Plan</p>
+<p>646-434-8528</p>
+<p>frankanderik.com</p>
+<p>Erik's Movember Page: <a href="http://mobro.co/erikcore">http://mobro.co/erikcore</a></p>
+<p>Frank's Movember Page: <a href="http://mobro.co/frankaugugliaro">http://mobro.co/frankaugugliaro</a></p>
+<p> </p>]]></content:encoded>
+			<enclosure length="55414857" type="audio/mpeg" url="http://traffic.libsyn.com/frankanderik/Internet_Famous_Ep124.mp3?dest-id=30697" />
+			<itunes:duration>01:55:02</itunes:duration>
+			<itunes:explicit>no</itunes:explicit>
+			<itunes:keywords />
+			<itunes:subtitle><![CDATA[Erk gets a little bit self righteous and Frank attempts to talk him down from a ledge.
+Break: Living With Lions - Pieces
+Outro: H2O - 5 Yr. Plan
+646-434-8528
+frankanderik.com
+Erik's Movember Page: http://mobro.co/erikcore
+Frank's Movember...]]></itunes:subtitle>
+					</item>
+				<item>
+			<title>Episode 29</title>
+			<pubDate>Wed, 12 Aug 2009 03:30:00 +0000</pubDate>
+			<guid isPermaLink="false"><![CDATA[http://frankanderik.libsyn.com/index.php?post_id=514338#]]></guid>
+			<link><![CDATA[http://frankanderik.libsyn.com/episode-29]]></link>
+			<itunes:image href="http://static.libsyn.com/p/assets/0/a/0/1/0a015c5ace601833/InternetFamousArt.jpg" />
+			<description><![CDATA[Frank and Erik talk about birthdays, gym teachers and screwing around at work before the internet.<br/>]]></description>
+			<content:encoded><![CDATA[Frank and Erik talk about birthdays, gym teachers and screwing around at work before the internet.]]></content:encoded>
+			<enclosure length="26019023" type="audio/mpeg" url="http://traffic.libsyn.com/frankanderik/Internet_Famous_Ep29.mp3?dest-id=30697" />
+			<itunes:duration>54:12</itunes:duration>
+			<itunes:explicit>no</itunes:explicit>
+			<itunes:keywords />
+			<itunes:subtitle><![CDATA[Frank and Erik talk about birthdays, gym teachers and screwing around at work before the internet.]]></itunes:subtitle>
+					</item>
+	</channel>
+</rss>

--- a/test/tests.js
+++ b/test/tests.js
@@ -427,6 +427,34 @@ describe('Podcast feed parser', () => {
     });
   });
 
+  it('should parse libsyn example feed episode', function(done) {
+    parse(fixtures['libsyn-example-podcast'], (err, data) => {
+      if (err) {
+        return done(err);
+      }
+
+      const podcast = Object.assign({}, data);
+
+      const firstEpisode = data.episodes[0];
+
+      expect(firstEpisode).to.eql({
+        guid: '1bdba530eb7cd0fb6241a945fda4db95',
+        title: 'Episode 128',
+        published: utcDate(2017, 3, 21, 3, 12, 13),
+        image: 'http://static.libsyn.com/p/assets/0/a/0/1/0a015c5ace601833/InternetFamousArt.jpg',
+        duration: 5702,
+        enclosure: {
+          filesize: 45813708,
+          type: 'audio/mpeg',
+          url: 'http://traffic.libsyn.com/frankanderik/Internet_Famous_Ep128.mp3?dest-id=30697'
+        },
+        // no categories
+      });
+
+      done();
+    });
+  });
+
   it('should parse complex genres', function(done) {
     parse(fixtures['complex-genre'], (err, data) => {
       if (err) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -440,6 +440,7 @@ describe('Podcast feed parser', () => {
       expect(firstEpisode).to.eql({
         guid: '1bdba530eb7cd0fb6241a945fda4db95',
         title: 'Episode 128',
+        description: '<p>Frank and Erik travel the world.</p> <p>Outro: 20/20 - Yellow Pills</p> <p>646-434-8528</p> <p>frankanderik.com</p>',
         published: utcDate(2017, 3, 21, 3, 12, 13),
         image: 'http://static.libsyn.com/p/assets/0/a/0/1/0a015c5ace601833/InternetFamousArt.jpg',
         duration: 5702,

--- a/test/tests.js
+++ b/test/tests.js
@@ -48,6 +48,7 @@ describe('Podcast feed parser', () => {
       expect(data).to.have.property('categories');
       expect(data).to.have.property('owner');
       expect(data).to.have.property('updated');
+      expect(data).to.have.property('explicit');
       expect(data).to.have.property('episodes');
 
       expect(data.title).to.be.a('string');
@@ -56,6 +57,7 @@ describe('Podcast feed parser', () => {
       expect(data.description.short).to.be.a('string');
       expect(data.description.long).to.be.a('string');
       expect(data.image).to.be.a('string');
+      expect(data.explicit).to.be.a('boolean');
       expect(data.categories).to.be.an(Array);
       expect(data.updated).to.be.a(Date);
       expect(data.episodes).to.be.an(Array);
@@ -70,6 +72,7 @@ describe('Podcast feed parser', () => {
       expect(episode).to.have.property('published');
       expect(episode).to.have.property('image');
       expect(episode).to.have.property('duration');
+      expect(episode).to.have.property('explicit');
       expect(episode).to.have.property('enclosure');
 
       expect(episode.guid).to.be.a('string');
@@ -77,6 +80,7 @@ describe('Podcast feed parser', () => {
       expect(episode.description).to.be.a('string');
       expect(episode.published).to.be.a(Date);
       expect(episode.image).to.be.a('string');
+      expect(episode.explicit).to.be.a('boolean');
       expect(episode.duration).to.be.a('number');
 
       expect(episode.enclosure).to.have.property('filesize');
@@ -110,6 +114,7 @@ describe('Podcast feed parser', () => {
           name: 'John Doe',
           email: 'john.doe@example.com'
         },
+        explicit: true,
         categories: [
           'Technology>Gadgets',
           'TV & Film',
@@ -126,6 +131,7 @@ describe('Podcast feed parser', () => {
         published: utcDate(2014, 5, 15, 19, 0, 0),
         image: 'http://example.com/podcasts/everything/AllAboutEverything/Episode1.jpg',
         duration: 424,
+        explicit: false,
         enclosure: {
           filesize: 8727310,
           type: 'audio/x-m4a',
@@ -161,6 +167,7 @@ describe('Podcast feed parser', () => {
           name: 'Kent C. Dodds',
           email: 'javascriptair@gmail.com'
         },
+        explicit: false,
         categories: [
           'Technology>Podcasting'
         ]
@@ -175,12 +182,14 @@ describe('Podcast feed parser', () => {
         title: '007 jsAir - Chakra, Microsoft’s Open Source JavaScript Engine with Ed Maurer, Gaurav Seth, and Steve Lucco',
         published: utcDate(2016, 0, 28, 0, 21, 35),
         // no image
+        explicit: false,
         duration: 3550,
         enclosure: {
           filesize: 56787979,
           type: 'audio/mpeg',
           url: 'http://javascriptair.podbean.com/mf/feed/dk3eif/JavaScriptAirEpisode007-ChakraMicrosoftsOpenSourceJavaScriptEngine.mp3'
         },
+        explicit: false,
         categories: [
           'Uncategorized'
         ]
@@ -213,6 +222,7 @@ describe('Podcast feed parser', () => {
           name: 'Christophe Limpalair',
           email: 'chris@scaleyourcode.com'
         },
+        explicit: true,
         categories: [
           'Technology'
         ]
@@ -227,6 +237,7 @@ describe('Podcast feed parser', () => {
         title: 'Large scale image processing on the fly in 25ms with Google\'s first Network Engineer',
         published: utcDate(2016, 1, 2, 1, 5, 26),
         image: 'https://d1ngwfo98ojxvt.cloudfront.net/images/interviews/jack_levin/jack-levin_opt_hi.jpg',
+        // no explicit
         // no duration
         enclosure: {
           filesize: undefined, // filesize not set
@@ -261,6 +272,7 @@ describe('Podcast feed parser', () => {
         owner: {
 
         },
+        explicit: false,
         categories: [
         ]
       });
@@ -293,9 +305,11 @@ describe('Podcast feed parser', () => {
           name: 'SE-Radio Team',
           email: 'team@se-radio.net'
         },
+        explicit: false,
         categories: [
           'Technology>Software How-To'
-        ]
+        ],
+        explicit: false,
       });
 
       expect(data.episodes).to.have.length(249);
@@ -307,12 +321,14 @@ describe('Podcast feed parser', () => {
         title: 'SE-Radio Episode 248: Axel Rauschmayer on JavaScript and ECMAScript 6',
         published: utcDate(2016, 0, 28, 18, 6, 52),
         image: 'http://media.computer.org/sponsored/podcast/se-radio/se-radio-logo-1400x1475.jpg',
+        explicit: false,
         duration: 3793,
         enclosure: {
           filesize: 151772209,
           type: 'audio/mpeg',
           url: 'http://feedproxy.google.com/~r/se-radio/~5/_V8a9ATpdxk/SE-Radio-Episode-248-Axel-Rauschmayer-on-JavaScript-and-ECMAScript-6.mp3'
         },
+        explicit: false,
         categories: [
           'Episodes',
           'ECMAScript',
@@ -347,6 +363,7 @@ describe('Podcast feed parser', () => {
           name: 'Spec.FM',
           email: 'designdetailsfm@gmail.com'
         },
+        explicit: false,
         categories: [
           'Technology',
           'Arts>Design',
@@ -364,6 +381,7 @@ describe('Podcast feed parser', () => {
         published: utcDate(2016, 1, 1, 13, 0, 0),
         image: 'https://media.simplecast.com/episode/image/25164/1454282072-artwork.jpg',
         duration: 3932,
+        explicit: true,
         enclosure: {
           filesize: 62948884,
           type: 'audio/mpeg',
@@ -400,9 +418,11 @@ describe('Podcast feed parser', () => {
           name: 'Graphistania',
           email: 'rik@neotechnology.com'
         },
+        explicit: false,
         categories: [
           'Technology'
-        ]
+        ],
+        explicit: false,
       });
 
       expect(data.episodes).to.have.length(54);
@@ -414,6 +434,7 @@ describe('Podcast feed parser', () => {
         title: 'Podcast Interview With Stuart Begg And Matt Byrne, Independent Contractors at Sensis',
         published: utcDate(2016, 0, 29, 0, 0, 0),
         image: 'http://i1.sndcdn.com/avatars-000135096101-qekfg1-original.png',
+        explicit: false,
         duration: 638,
         enclosure: {
           filesize: 6381794,
@@ -443,6 +464,7 @@ describe('Podcast feed parser', () => {
         description: '<p>Frank and Erik travel the world.</p> <p>Outro: 20/20 - Yellow Pills</p> <p>646-434-8528</p> <p>frankanderik.com</p>',
         published: utcDate(2017, 3, 21, 3, 12, 13),
         image: 'http://static.libsyn.com/p/assets/0/a/0/1/0a015c5ace601833/InternetFamousArt.jpg',
+        explicit: false,
         duration: 5702,
         enclosure: {
           filesize: 45813708,
@@ -451,6 +473,21 @@ describe('Podcast feed parser', () => {
         },
         // no categories
       });
+
+      done();
+    });
+  });
+
+  it('should parse isExplicit', function(done) {
+    parse(fixtures['libsyn-example-podcast'], (err, data) => {
+      if (err) {
+        return done(err);
+      }
+      const podcast = Object.assign({}, data);
+      const firstEpisode = data.episodes[0];
+
+      expect(podcast.explicit).to.equal(true);
+      expect(firstEpisode.explicit).to.equal(false);
 
       done();
     });


### PR DESCRIPTION
This normalizes a new <itunes:explicit> tag to `explicit: true|false` and adds support for finding episode descriptions in <description> (Libsyn feeds)

Supported with tests.