### PR TITLE
fix issue #11 and retrieve url from channel image

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,11 @@ module.exports = function parse(feedXML, callback) {
       };
     } else if (node.name === 'itunes:image' && node.parent.name === 'channel') {
       result.image = node.attributes.href;
+    } else if (node.name === 'image' && node.parent.name === 'channel' && !result.image) {
+      result.image = node.target = {};
+      node.textMap = {
+        'url': true,
+      };
     } else if (node.name === 'itunes:owner' && node.parent.name === 'channel') {
       result.owner = node.target = {};
       node.textMap = {
@@ -139,6 +144,9 @@ module.exports = function parse(feedXML, callback) {
       tmpEpisode.description = description;
       result.episodes.push(tmpEpisode);
       tmpEpisode = null;
+    }
+    if (name === 'image' && result.hasOwnProperty('image') && result.image.hasOwnProperty('url')) {
+      result.image = result.image.url;
     }
   };
 

--- a/test/fixtures/image-with-children.rss
+++ b/test/fixtures/image-with-children.rss
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:media="http://search.yahoo.com/mrss/" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>Image With Children Channel</title>
+    <link>https://www.example.com/channel-link</link>
+    <description>This channel has an image that also has title and link information.</description>
+    <image>
+      <title>Image Title</title>
+      <url>https://www.example.com/channel-image.png</url>
+      <link>https://www.example.com/channel-link</link>
+    </image>
+    <language>en-nz</language>
+    <copyright>(C) Example 2018</copyright>
+  </channel>
+</rss>

--- a/test/tests.js
+++ b/test/tests.js
@@ -535,6 +535,31 @@ describe('Podcast feed parser', () => {
     });
   });
 
+  it('should parse image with children feed', function(done) {
+    parse(fixtures['image-with-children'], (err, data) => {
+      if (err) {
+        return done(err);
+      }
+
+      const podcast = Object.assign({}, data);
+      delete podcast.episodes;
+
+      expect(podcast).to.eql({
+        title: 'Image With Children Channel',
+        description: {
+          long: 'This channel has an image that also has title and link information.'
+        },
+        link: 'https://www.example.com/channel-link',
+        image: 'https://www.example.com/channel-image.png',
+        language: 'en-nz',
+        updated: null,
+        categories: []
+      });
+
+      done();
+    });
+  });
+
   it('should parse isExplicit', function(done) {
     parse(fixtures['libsyn-example-podcast'], (err, data) => {
       if (err) {


### PR DESCRIPTION
fix issue #11 and retrieve url from channel image with title/url/link child elements.

Example of the sort of image that was being ignored previously:
```xml
<image>
  <title>Image Title</title>
  <url>https://www.example.com/channel-image.png</url>
  <link>https://www.example.com/channel-link</link>
</image>
```
This commit will now read the `<url>` child element from `<image>` into the `image` property on the output.
This commit will continue to ignore the title and link from the `<image>` child elements.