### PR TITLE
Handle missing publication date for items

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -182,8 +182,9 @@ module.exports = function parse(feedXML, callback) {
   parser.onend = function() {
     // sort by date descending
     if (result.episodes) {
-      result.episodes = result.episodes.sort((item1, item2) => {
-        return item2.published.getTime() - item1.published.getTime();
+      const noDate = new Date(0);
+      result.episodes = result.episodes.sort(function (item1, item2) {
+        return (item2.published || noDate).getTime() - (item1.published || noDate).getTime();
       });
     }
 

--- a/test/fixtures/no-pubdate.xml
+++ b/test/fixtures/no-pubdate.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>All About Everything</title>
+    <link>http://www.example.com/podcasts/everything/index.html</link>
+    <language>en-us</language>
+    <copyright>℗ &amp; © 2014 John Doe &amp; Family</copyright>
+    <itunes:subtitle>A show about everything</itunes:subtitle>
+    <itunes:author>John Doe</itunes:author>
+    <itunes:summary>All About Everything is a show about everything. Each week we dive into any subject known to man and talk about it as much as we can. Look for our podcast in the Podcasts app or in the iTunes Store</itunes:summary>
+    <description>All About Everything is a show about everything. Each week we dive into any subject known to man and talk about it as much as we can. Look for our podcast in the Podcasts app or in the iTunes Store</description>
+    <itunes:owner>
+      <itunes:name>John Doe</itunes:name>
+      <itunes:email>john.doe@example.com</itunes:email>
+    </itunes:owner>
+    <itunes:image href="http://example.com/podcasts/everything/AllAboutEverything.jpg"/>
+    <itunes:explicit>yes</itunes:explicit>
+    <itunes:category text="Technology">
+      <itunes:category text="Gadgets"/>
+    </itunes:category>
+    <itunes:category text="TV &amp; Film"/>
+    <item>
+      <title>Shake Shake Shake Your Spices</title>
+      <itunes:author>John Doe</itunes:author>
+      <itunes:subtitle>A short primer on table spices</itunes:subtitle>
+      <itunes:summary><![CDATA[This week we talk about
+        <a href="https://itunes/apple.com/us/book/antique-trader-salt-pepper/id429691295?mt=11">salt and pepper shakers</a>
+        , comparing and contrasting pour rates, construction materials, and overall aesthetics. Come and join the party!]]></itunes:summary>
+      <itunes:image href="http://example.com/podcasts/everything/AllAboutEverything/Episode1.jpg"/>
+      <enclosure length="8727310" type="audio/x-m4a" url="http://example.com/podcasts/everything/AllAboutEverythingEpisode3.m4a"/>
+      <guid>http://example.com/podcasts/archive/aae20140615.m4a</guid>
+      <itunes:duration>7:04</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>Socket Wrench Shootout</title>
+      <itunes:author>Jane Doe</itunes:author>
+      <itunes:subtitle>Comparing socket wrenches is fun!</itunes:subtitle>
+      <itunes:summary>This week we talk about metric vs. Old English socket wrenches. Which one is better? Do you really need both? Get all of your answers here.</itunes:summary>
+      <itunes:image href="http://example.com/podcasts/everything/AllAboutEverything/Episode2.jpg"/>
+      <enclosure length="5650889" type="audio/mpeg" url="http://example.com/podcasts/everything/AllAboutEverythingEpisode2.mp3"/>
+      <guid>http://example.com/podcasts/archive/aae20140608.mp3</guid>
+      <itunes:duration>4:34</itunes:duration>
+      <itunes:explicit>no</itunes:explicit>
+    </item>
+    <item>
+      <title>Red,Whine, &amp; Blue</title>
+      <itunes:author>Various</itunes:author>
+      <itunes:subtitle>Red + Blue != Purple</itunes:subtitle>
+      <itunes:summary>This week we talk about surviving in a Red state if you are a Blue person. Or vice versa.</itunes:summary>
+      <itunes:image href="http://example.com/podcasts/everything/AllAboutEverything/Episode3.jpg"/>
+      <enclosure length="498537" type="audio/mpeg" url="http://example.com/podcasts/everything/AllAboutEverythingEpisode1.mp3"/>
+      <guid>http://example.com/podcasts/archive/aae20140601.mp3</guid>
+      <itunes:duration>3:59</itunes:duration>
+      <itunes:explicit>yes</itunes:explicit>
+    </item>
+  </channel>
+</rss>

--- a/test/tests.js
+++ b/test/tests.js
@@ -146,6 +146,58 @@ describe('Podcast feed parser', () => {
     });
   });
 
+  it('should parse feed when items have no pubdate', function(done) {
+    parse(fixtures['no-pubdate'], (err, data) => {
+      if (err) {
+        return done(err);
+      }
+
+      const podcast = Object.assign({}, data);
+      delete podcast.episodes;
+
+      expect(podcast).to.eql({
+        title: 'All About Everything',
+        description: {
+          short: 'A show about everything',
+          long: 'All About Everything is a show about everything. Each week we dive into any subject known to man and talk about it as much as we can. Look for our podcast in the Podcasts app or in the iTunes Store',
+        },
+        link: 'http://www.example.com/podcasts/everything/index.html',
+        image: 'http://example.com/podcasts/everything/AllAboutEverything.jpg',
+        language: 'en-us',
+        updated: undefined,
+        author: 'John Doe',
+        owner: {
+          name: 'John Doe',
+          email: 'john.doe@example.com'
+        },
+        explicit: true,
+        categories: [
+          'Technology>Gadgets',
+          'TV & Film',
+        ]
+      });
+
+      expect(data.episodes).to.have.length(3);
+      const firstEpisode = data.episodes[0];
+      delete firstEpisode.description;
+
+      expect(firstEpisode).to.eql({
+        guid: 'http://example.com/podcasts/archive/aae20140615.m4a',
+        title: 'Shake Shake Shake Your Spices',
+        image: 'http://example.com/podcasts/everything/AllAboutEverything/Episode1.jpg',
+        duration: 424,
+        explicit: false,
+        enclosure: {
+          filesize: 8727310,
+          type: 'audio/x-m4a',
+          url: 'http://example.com/podcasts/everything/AllAboutEverythingEpisode3.m4a'
+        }
+      });
+
+      done();
+    });
+  });
+
   it('should parse javascript air feed', function(done) {
     parse(fixtures['javascript-air'], (err, data) => {
       if (err) {


### PR DESCRIPTION
Sometimes feed items doesn't have a publication date, and when it happens the sorting algorithm breaks causing the parser to fail. This PR address the issue using a default date in the past for items that has no publication date.